### PR TITLE
build(deps/example):  fastxml-woodstoxの脆弱性がDokka経由で取り込まれているため、dokka依存を除去

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("java")
-    alias(libs.plugins.dokka)
     alias(libs.plugins.detekt)
 }
 

--- a/example/gradle/custom.versions.toml
+++ b/example/gradle/custom.versions.toml
@@ -26,8 +26,6 @@ zero-allocation-hashing = "0.26ea0"
 detekt = "io.gitlab.arturbosch.detekt:1.23.7"
 ##                                 ^ "1.23.8"
 
-dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
-
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm",     version.ref = "kotlin" }
 
 [libraries]


### PR DESCRIPTION
exampleプロジェクトであるため、dokkaである必要がない