### PR TITLE
build: okioを明示的に依存に追加

### DIFF
--- a/plugin-build/gradle/libs.versions.toml
+++ b/plugin-build/gradle/libs.versions.toml
@@ -22,6 +22,8 @@ mockk = "1.14.2"
 
 okhttp = "5.0.0-alpha.14"
 
+okio = "3.9.1"
+
 [libraries]
 
 detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
@@ -53,6 +55,8 @@ okhttp-core = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "
 okhttp-coroutines = { group = "com.squareup.okhttp3", name = "okhttp-coroutines", version.ref = "okhttp" }
 
 okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
+
+okio = { group = "com.squareup.okio", name = "okio-jvm", version.ref = "okio" }
 
 [plugins]
 

--- a/plugin-build/plugin/build.gradle.kts
+++ b/plugin-build/plugin/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(libs.okhttp.core)
     implementation(libs.okhttp.coroutines)
     implementation(libs.okhttp.logging.interceptor)
+    implementation(libs.okio)
 
     detektPlugins(libs.detekt.formatting)
 


### PR DESCRIPTION
okioをokhttp3経由で使用しているが、okioのバージョンが古くなっているため
ただ、3.10.0以降はkotlin2.0以降を要求されるため、3.9.1までとする