### PR TITLE
build: jacksonの脆弱性対応

### DIFF
--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 allprojects {
     configurations.all {
         resolutionStrategy {
+            force(libs.fastxml.jackson.databind)
             force(libs.fastxml.woodstox)
         }
     }

--- a/plugin-build/gradle/libs.versions.toml
+++ b/plugin-build/gradle/libs.versions.toml
@@ -6,6 +6,8 @@ detekt = "1.23.8"
 
 dokka = "2.0.0"
 
+fastxml-jackson = "2.13.5"
+
 fastxml-woodstox = "7.1.1"
 
 kotest = "5.9.1"
@@ -27,6 +29,8 @@ okio = "3.9.1"
 [libraries]
 
 detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
+
+fastxml-jackson-databind = { group = "com.fasterxml.jackson.core", name = "jackson-databind", version.ref = "fastxml-jackson" }
 
 fastxml-woodstox = { group = "com.fasterxml.woodstox", name = "woodstox-core", version.ref = "fastxml-woodstox" }
 


### PR DESCRIPTION
dokka v2が2.12.7に依存しているため、強制的に2.13.5にアップデートする