### PR TITLE
build(deps)!: kotlin 2.1系にアップデート

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.21" />
+    <option name="version" value="2.1.21" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ plugins {
 
 ## Usage
 
-Currently, Gradle 8.0 or later is supported.
+Currently, Gradle 8.7 or later is supported.
 
 ### Find available updates in versions catalog
 

--- a/example/gradle/custom.versions.toml
+++ b/example/gradle/custom.versions.toml
@@ -14,6 +14,7 @@ dokka = "1.9.0"
 # resolutionStrategyで参照されている
 fastxml-woodstox = "7.0.0"
 ##               ^ "7.1.0"
+##               ^ "7.1.1"
 
 kotlin = "2.1.0"
 ##     ^ "2.1.10-RC"
@@ -25,6 +26,14 @@ kotlin = "2.1.0"
 ##     ^ "2.1.20-RC2"
 ##     ^ "2.1.20-RC3"
 ##     ^ "2.1.20"
+##     ^ "2.1.21-RC"
+##     ^ "2.1.21-RC2"
+##     ^ "2.1.21"
+##     ^ "2.2.0-Beta1"
+##     ^ "2.2.0-Beta2"
+##     ^ "2.2.0-RC"
+##     ^ "2.2.0-RC2"
+##     ^ "2.2.0-RC3"
 
 truth = "1.4.4"
 
@@ -52,6 +61,7 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib" }
 
 kotlinx-coroutines-bom = "org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.10.0"
 ##                                                                  ^ "1.10.1"
+##                                                                  ^ "1.10.2"
 
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core" }
 
@@ -59,9 +69,13 @@ kotest-bom = { group = "io.kotest", version = "5.9.0", name = "kotest-bom"      
 ##                                          ^ "5.9.1", name = "kotest-bom"        }
 ##                                          ^ "6.0.0.M1", name = "kotest-bom"        }
 ##                                          ^ "6.0.0.M2", name = "kotest-bom"        }
+##                                          ^ "6.0.0.M3", name = "kotest-bom"        }
+##                                          ^ "6.0.0.M4", name = "kotest-bom"        }
 
 mockk = "io.mockk:mockk:1.13.16"
 ##                   ^ "1.13.17"
+##                   ^ "1.14.0"
+##                   ^ "1.14.2"
 
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
 

--- a/plugin-build/gradle/libs.versions.toml
+++ b/plugin-build/gradle/libs.versions.toml
@@ -12,9 +12,9 @@ fastxml-woodstox = "7.1.1"
 
 kotest = "5.9.1"
 
-kotlin = "1.9.25"
+kotlin = "2.1.21"
 
-kotlinx-coroutines = "1.8.1"
+kotlinx-coroutines = "1.10.2"
 
 kover = "0.9.1"
 
@@ -22,9 +22,9 @@ maven-publish = "0.32.0"
 
 mockk = "1.14.2"
 
-okhttp = "5.0.0-alpha.14"
+okhttp = "5.0.0-alpha.16"
 
-okio = "3.9.1"
+okio = "3.13.0"
 
 [libraries]
 


### PR DESCRIPTION
- kotlin 1.9.25 -> 2.1.21
- kotlinx coroutines 1.8.1 -> 1.10.2
- okhttp 5.0.0-alpha.14 -> 5.0.0-alpha.16
- okio 3.9.1 -> 3.13.0