### PR TITLE
ci: リリーストリガーをタグ作成時に変更

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,15 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Verify tag matches project version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          FILE_VERSION=$(grep -m1 '^version = ' plugin-build/plugin/build.gradle.kts | sed -E 's/version = "(.*)"/\1/')
+          if [ "$TAG_VERSION" != "$FILE_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match build.gradle.kts version ($FILE_VERSION)"
+            exit 1
+          fi
+
       - name: Setup JDK ${{ matrix.java-version }}
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,9 @@
 name: Release
 
 on:
-  workflow_dispatch:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - 'v*.*.*'
 
 permissions: {}
 
@@ -16,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
+      contents: write
 
     strategy:
       matrix:
@@ -47,3 +46,9 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
+
+      - name: Create GitHub Release
+        run: gh release create "$TAG_NAME" --generate-notes --verify-tag
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
不変リリースであるため、ビルド中にエラーが発生すると、不完全リリースを取り消す事が出来ない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **リリース**
  * `v*.*.*`形式のバージョンタグをプッシュすると、リリース処理が自動実行されるようになりました。
  * タグのバージョンとアプリのバージョンが一致するか検証します。
  * Maven Centralへの公開後、GitHubリリースを自動作成します。
  * リリースノートが自動生成されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->